### PR TITLE
Fix zlib.lib path

### DIFF
--- a/07_Build_Library.bat
+++ b/07_Build_Library.bat
@@ -68,7 +68,7 @@ cd ..
 echo Build quazip
 cd quazip-1.4
 
-dir ..\zlib-src\build64\Release\zlib.lib
+dir ..\zlib-src\build64\Release\zs.lib
 
 set Qt6_DIR=C:\Qt\6.5.3\msvc2019_64
 dir %Qt6_DIR%
@@ -81,7 +81,7 @@ cmake -S . -B build64 ^
   -D CMAKE_INSTALL_PREFIX=..\quazip-6.5.3-1.4 ^
   -D QUAZIP_USE_QT_ZLIB=OFF ^
   -D ZLIB_INCLUDE_DIR=..\zlib-src ^
-  -D ZLIB_LIBRARY=%cd%\..\zlib-src\build64\Release\zlib.lib
+  -D ZLIB_LIBRARY=%cd%\..\zlib-src\build64\Release\zs.lib
 if not "%ERRORLEVEL%" == "0" goto failed
 
 cmake --build build64 --config Release


### PR DESCRIPTION
Changes the file name from zlib.lib to zs.lib, fixes an cannot find zlib.lib file error that i encountered.